### PR TITLE
Improve removing the magic prefix from the JSON response

### DIFF
--- a/lib/gerry/client/request.rb
+++ b/lib/gerry/client/request.rb
@@ -77,7 +77,9 @@ module Gerry
       end
 
       def remove_magic_prefix(response_body)
-        response_body.lines.to_a[1..-1].join
+        # We need to strip the magic prefix from the first line of the response, see
+        # https://gerrit-review.googlesource.com/Documentation/rest-api.html#output.
+        response_body.sub(/^\)\]\}'$/, '')
       end
     end
   end

--- a/spec/fixtures/query_capabilities.json
+++ b/spec/fixtures/query_capabilities.json
@@ -1,4 +1,4 @@
- )]}'
+)]}'
   {
     "createAccount": true,
     "createGroup": true


### PR DESCRIPTION
Do not unconditionally remove the first line but check that it really
contains the magic prefix. This also does not convert the whole response
to an array just to join it later again.