### PR TITLE
Add a method to set the symbolic HEAD ref for a project

### DIFF
--- a/lib/gerry/client/projects.rb
+++ b/lib/gerry/client/projects.rb
@@ -7,8 +7,8 @@ module Gerry
       def projects
         get('/projects/')
       end
-      
-      # Get the projects that start with the specified prefix 
+
+      # Get the projects that start with the specified prefix
       # and accessible by the caller.
       #
       # @param [String] name the project name.

--- a/lib/gerry/client/projects.rb
+++ b/lib/gerry/client/projects.rb
@@ -16,6 +16,28 @@ module Gerry
       def find_project(name)
         get("/projects/#{name}")
       end
+
+      # Get the symbolic HEAD ref for the specified project.
+      #
+      # @param [String] project the project name.
+      # @return [String] the current ref to which HEAD points to.
+      def get_head(project)
+        get("/projects/#{project}/HEAD")
+      end
+
+      # Set the symbolic HEAD ref for the specified project to
+      # point to the specified branch.
+      #
+      # @param [String] project the project name.
+      # @param [String] branch the branch to point to.
+      # @return [String] the new ref to which HEAD points to.
+      def set_head(project, branch)
+        url = "/projects/#{project}/HEAD"
+        body = {
+          ref: 'refs/heads/' + branch
+        }
+        put(url, body)
+      end
     end
   end
 end

--- a/lib/gerry/client/request.rb
+++ b/lib/gerry/client/request.rb
@@ -65,7 +65,14 @@ module Gerry
           raise_request_error(response)
         end
         if response.body
-          JSON.parse(remove_magic_prefix(response.body))
+          source = remove_magic_prefix(response.body)
+          if source.lines.count == 1 && !source.start_with?('{') && !source.start_with?('[')
+            # Work around the JSON gem not being able to parse top-level values, see
+            # https://github.com/flori/json/issues/206.
+            source.gsub!(/^"|"$/, '')
+          else
+            JSON.parse(source)
+          end
         else
           nil
         end
@@ -79,7 +86,7 @@ module Gerry
       def remove_magic_prefix(response_body)
         # We need to strip the magic prefix from the first line of the response, see
         # https://gerrit-review.googlesource.com/Documentation/rest-api.html#output.
-        response_body.sub(/^\)\]\}'$/, '')
+        response_body.sub(/^\)\]\}'$/, '').strip!
       end
     end
   end

--- a/lib/gerry/client/request.rb
+++ b/lib/gerry/client/request.rb
@@ -27,14 +27,14 @@ module Gerry
       def put(url, body)
         if @username && @password
           auth = { username: @username, password: @password }
-          response = self.class.put("/a#{url}", 
-            body: body.to_json, 
+          response = self.class.put("/a#{url}",
+            body: body.to_json,
             headers: { 'Content-Type' => 'application/json' },
             digest_auth: auth
           )
           parse(response)
         else
-          response = self.class.put(url, 
+          response = self.class.put(url,
             body: body.to_json,
             headers: { 'Content-Type' => 'application/json' }
           )
@@ -45,14 +45,14 @@ module Gerry
       def post(url, body)
         if @username && @password
           auth = { username: @username, password: @password }
-          response = self.class.post("/a#{url}", 
-            body: body.to_json, 
+          response = self.class.post("/a#{url}",
+            body: body.to_json,
             headers: { 'Content-Type' => 'application/json' },
             digest_auth: auth
           )
           parse(response)
         else
-          response = self.class.post(url, 
+          response = self.class.post(url,
             body: body.to_json,
             headers: { 'Content-Type' => 'application/json' }
           )

--- a/spec/fixtures/project_head.json
+++ b/spec/fixtures/project_head.json
@@ -1,0 +1,2 @@
+)]}'
+"refs/heads/stable"

--- a/spec/fixtures/projects.json
+++ b/spec/fixtures/projects.json
@@ -1,9 +1,9 @@
 )]}'
 {
   "awesome": {
-  	 "description": "Awesome project"
+    "description": "Awesome project"
   },
   "clean": {
-  	 "description": "Clean code!"
+    "description": "Clean code!"
   }
 }

--- a/spec/projects_spec.rb
+++ b/spec/projects_spec.rb
@@ -23,4 +23,32 @@ describe '.projects' do
 
     expect(projects['awesome']['description']).to eq('Awesome project')
   end
+
+  it 'should resolve the symbolic HEAD ref of a project' do
+    project = 'awesome'
+    stub = stub_get("/projects/#{project}/HEAD", 'project_head.json')
+
+    client = MockGerry.new
+    branch = client.get_head(project)
+
+    expect(stub).to have_been_requested
+
+    expect(branch).to eq('refs/heads/stable')
+  end
+
+  it 'should define the symbolic HEAD ref of a project' do
+    project = 'awesome'
+    branch = 'stable'
+    input = {
+      ref: 'refs/heads/' + branch
+    }
+    stub = stub_put("/projects/#{project}/HEAD", input.to_json, get_fixture('project_head.json'))
+
+    client = MockGerry.new
+    new_branch = client.set_head(project, branch)
+
+    expect(stub).to have_been_requested
+
+    expect(new_branch).to eq('refs/heads/' + branch)
+  end
 end

--- a/spec/projects_spec.rb
+++ b/spec/projects_spec.rb
@@ -1,26 +1,26 @@
 require 'spec_helper'
 
-describe '.projects' do    
+describe '.projects' do
   it 'should fetch all projects' do
-    stub = stub_get('/projects/', 'projects.json')                     
-    
+    stub = stub_get('/projects/', 'projects.json')
+
     client = MockGerry.new
     projects = client.projects
-    
+
     expect(stub).to have_been_requested
-    
+
     expect(projects['awesome']['description']).to eq('Awesome project')
     expect(projects['clean']['description']).to eq('Clean code!')
   end
-  
+
   it 'should fetch a project' do
-    stub = stub_get('/projects/awesome', 'projects.json')                     
-    
+    stub = stub_get('/projects/awesome', 'projects.json')
+
     client = MockGerry.new
     projects = client.find_project('awesome')
-    
+
     expect(stub).to have_been_requested
-    
+
     expect(projects['awesome']['description']).to eq('Awesome project')
   end
 end


### PR DESCRIPTION
For that to work I needed to work around a bug in the JSON gem when parsing top-level values.