### PR TITLE
Handle large request results

### DIFF
--- a/lib/gerry/client/changes.rb
+++ b/lib/gerry/client/changes.rb
@@ -7,13 +7,13 @@ module Gerry
       # @return [Hash] the changes.
       def changes(options = [])
         url = '/changes/'
-        
+
         if options.empty?
           return get(url)
         end
-        
+
         options = map_options(options)
-        get("#{url}?#{options}")        
+        get("#{url}?#{options}")
       end
     end
   end


### PR DESCRIPTION
This transparently handles pagination if requests are larger than the internal / specified result limit.