### PR TITLE
Move pagination support from "request" to "changes"

### DIFF
--- a/spec/changes_spec.rb
+++ b/spec/changes_spec.rb
@@ -20,6 +20,7 @@ describe '.changes' do
   it 'should fetch all changes in batches' do
     stub_batch_0 = stub_get('/changes/', 'changes_batch_0.json')
     stub_batch_1 = stub_get('/changes/?S=1', 'changes_batch_1.json')
+    stub_batch_2 = stub_get('/changes/?S=2', 'changes_batch_2.json')
 
     client = MockGerry.new
     changes = client.changes
@@ -29,10 +30,15 @@ describe '.changes' do
 
     expect(changes[0]['project']).to eq('awesome')
     expect(changes[0]['branch']).to eq('master')
+    expect(changes[0]['owner']['name']).to eq('The Duke')
 
     expect(changes[1]['project']).to eq('clean')
     expect(changes[1]['subject']).to eq('Refactor code')
     expect(changes[1]['owner']['name']).to eq('Batman')
+
+    expect(changes[2]['project']).to eq('X')
+    expect(changes[2]['subject']).to eq('Remove unused imports')
+    expect(changes[2]['owner']['name']).to eq('Bill')
   end
 
   it 'should fetch all open changes' do

--- a/spec/fixtures/changes_batch_1.json
+++ b/spec/fixtures/changes_batch_1.json
@@ -12,6 +12,7 @@
     "_number": 42,
     "owner": {
       "name": "Batman"
-    }
+    },
+    "_more_changes": true
   }
 ]

--- a/spec/fixtures/changes_batch_2.json
+++ b/spec/fixtures/changes_batch_2.json
@@ -1,0 +1,17 @@
+)]}'
+[
+  {
+    "project": "X",
+    "branch": "default",
+    "id": "Ieb185f4da8725ae35e9f940e614c6eaa7b88eff5",
+    "subject": "Remove unused imports",
+    "status": "NEW",
+    "created": "2016-01-11 15:51:30.605000000",
+    "updated": "2016-02-12 00:45:26.431000000",
+    "_sortkey": "002e4203000187d5",
+    "_number": 4711,
+    "owner": {
+      "name": "Bill"
+    }
+  }
+]


### PR DESCRIPTION
Basically, putting pagination support into "request" is teh more generic
place, but doing so requires some additonal checks as so far üagination is
only done for changes. So to keep things simple, move pagination support
to "changes" which allows for some simplifications. If other requests ever
get pagination support we can again move it to "request".