### PR TITLE
Fix a possible nil error

### DIFF
--- a/lib/gerry/client/changes.rb
+++ b/lib/gerry/client/changes.rb
@@ -16,7 +16,7 @@ module Gerry
         end
 
         response = get(url)
-        return response unless response.last.delete('_more_changes')
+        return response if response.empty? || !response.last.delete('_more_changes')
 
         # Get the original start parameter, if any, else start from 0.
         query = URI.parse(url).query


### PR DESCRIPTION
For an empty response, ".last" returns nil, so check for the response to
not be empty before calling ".delete()".