### PR TITLE
Deprecate set_auth_type

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,8 @@ client.changes(['q=is:open'])
 ```
 
 ### Authentication type
-Gerrit uses digest authentication by default. This can be changed by
-configuring `auth.gitBasicAuth = true`. If the gerrit server uses
-basic authentication, you need to specify it:
-```ruby
-client = Gerry.new('https://review', 'user', 'p455w0rd')
-client.set_auth_type(:basic_auth)
-```
+Since 2.14, Gerrit no longer supports digest authentication.
+Gerry uses basic authentication against gerrit.
 
 ## Licence
 The MIT Licence

--- a/lib/gerry/client.rb
+++ b/lib/gerry/client.rb
@@ -36,7 +36,7 @@ module Gerry
     include Api::Request
 
     def set_auth_type(auth_type)
-      @auth_type = auth_type
+      warn 'set_auth_type is deprecated. digest auth is no longer supported'
     end
 
     def initialize(url, username = nil, password = nil)
@@ -44,7 +44,6 @@ module Gerry
       if username && password
         self.class.basic_auth(username, password)
       end
-      @auth_type = :digest_auth
 
       if username && password
         @username = username

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -20,26 +20,6 @@ describe '.get' do
     expect(stub).to have_been_requested
   end
 
-  it 'should request projects as user with digest auth' do
-    username = 'gerry'
-    password = 'whoop'
-
-    body = get_fixture('projects.json')
-
-    stub = stub_request(:get, "http://localhost/a/projects/").
-             with(:headers => {'Accept'=>'application/json'}).
-             to_return(:status => 200, :body => body, :headers => {})
-
-    client = Gerry.new(MockGerry::URL, 'gerry', 'whoop')
-    projects = client.projects
-
-    # twice because the first is the auth challenge and then the actual request
-    expect(stub).to have_been_requested
-
-    expect(projects['awesome']['description']).to eq('Awesome project')
-    expect(projects['clean']['description']).to eq('Clean code!')
-  end
-
   it 'should request projects as user with basic auth' do
     username = 'gerry'
     password = 'whoop'
@@ -56,7 +36,6 @@ describe '.get' do
              ).to_return(:status => 200, :body => body, :headers => {})
 
     client = Gerry.new(MockGerry::URL, 'gerry', 'whoop')
-    client.set_auth_type(:basic_auth)
     projects = client.projects
 
     expect(stub).to have_been_requested


### PR DESCRIPTION
Gerrit doesn't support digest auth since 2.14, and it was effectively
removed in 5cc82654e491a32f100fad8fbba7ef4a454aa7f9 which no longer
consider @auth_type.

Make it official, and add a deprecation warning.