### PR TITLE
Revert "Source netrc from github"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
 gemspec
-gem 'netrc', :git => 'https://github.com/heroku/netrc.git'
+gem 'netrc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,3 @@
-GIT
-  remote: https://github.com/heroku/netrc.git
-  revision: 262ef111199058f89df4573c4f04aae65e5e5041
-  specs:
-    netrc (0.11.0)
-
 PATH
   remote: .
   specs:
@@ -46,6 +40,7 @@ GEM
     method_source (0.9.0)
     multi_xml (0.6.0)
     nenv (0.3.0)
+    netrc (0.11.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -90,7 +85,7 @@ DEPENDENCIES
   gerry!
   guard
   guard-rspec
-  netrc!
+  netrc
   pry
   rack-test
   rake


### PR DESCRIPTION
0.11 was released on 2015, and there's only a single commit
which is rarely needed in the repo.

This reverts commit 85e471ac79207abe2186df006160a1fc5db9cbaf.